### PR TITLE
Fix #50, #84 and #72

### DIFF
--- a/src/js/footer/060-more.js
+++ b/src/js/footer/060-more.js
@@ -6,7 +6,11 @@ for( var i = 0; i < wrapper.length; i++ ) {
 	if( contributors > 4 ) {
 		wrapper[ i ].insertAdjacentHTML(
 			'beforeend',
-			'<li><button type="button" class="component-status__definition__list__more js-more">+' + ( contributors - 4 ) + '</button></li>'
+			'<li>' +
+				'<button type="button" class="component-status__definition__list__more js-more">' +
+					'<span class="sronly">View </span> +' + ( contributors - 4 ) + '<span class="sronly"> more contributors</span>' +
+				'</button>' +
+			'</li>'
 		);
 		AddClass( wrapper[ i ], 'is-small' );
 	}

--- a/src/layout/404.js
+++ b/src/layout/404.js
@@ -64,7 +64,7 @@ const Page = ({
 			{ header }
 			<div className="page-wrapper">
 				<div className="content-wrapper">
-					<main tabIndex="0" id="content" className="main au-body container-fluid">
+					<main tabIndex="-1" id="content" className="main au-body container-fluid">
 						<div className="row">
 							<div className="col-md-12">
 								<h1 className={

--- a/src/layout/404.js
+++ b/src/layout/404.js
@@ -64,7 +64,7 @@ const Page = ({
 			{ header }
 			<div className="page-wrapper">
 				<div className="content-wrapper">
-					<main id="content" className="main au-body container-fluid">
+					<main tabIndex="0" id="content" className="main au-body container-fluid">
 						<div className="row">
 							<div className="col-md-12">
 								<h1 className={

--- a/src/layout/component/page.js
+++ b/src/layout/component/page.js
@@ -90,7 +90,7 @@ const ComponentPage = ({
 							<div className="col-md-3 sidebar">
 								{ sidebar }
 							</div>
-							<div id="content" tabIndex="0" className="col-md-9 content">
+							<div id="content" tabIndex="-1" className="col-md-9 content">
 								{
 									showheader &&
 									<Fragment>
@@ -112,7 +112,7 @@ const ComponentPage = ({
 										{ component_nav }
 									</Fragment>
 								}
-								<div tabIndex="0" className="componentdocumentation" id="component-documentation">
+								<div tabIndex="-1" className="componentdocumentation" id="component-documentation">
 									{ main }
 								</div>
 								{

--- a/src/layout/component/page.js
+++ b/src/layout/component/page.js
@@ -1,6 +1,8 @@
 import Navigation      from './../navigation';
 import ComponentHeader from './header';
 import ComponentFooter from './footer';
+import AUskipLink      from '../../_uikit/layout/skip-link';
+
 
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
@@ -88,7 +90,13 @@ const ComponentPage = ({
 							<div className="col-md-3 sidebar">
 								{ sidebar }
 							</div>
-							<div id="content" className="col-md-9 content">
+							<div id="content" tabIndex="0" className="col-md-9 content">
+								<AUskipLink links={[
+									{
+										link: '#component-documentation',
+										text: `Skip to ${ pagetitle }`,
+									},
+								]} />
 								{
 									showheader && <Fragment>
 										<ComponentHeader
@@ -103,7 +111,9 @@ const ComponentPage = ({
 										{ component_nav }
 									</Fragment>
 								}
-								{ main }
+								<div tabIndex="0" className="componentdocumentation" id="component-documentation">
+									{ main }
+								</div>
 								{
 									showheader && <ComponentFooter _ID={ _ID } _parseYaml={ _parseYaml } _relativeURL={ _relativeURL } _pages={ _pages } _parents= { _parents } />
 								}

--- a/src/layout/component/page.js
+++ b/src/layout/component/page.js
@@ -91,14 +91,15 @@ const ComponentPage = ({
 								{ sidebar }
 							</div>
 							<div id="content" tabIndex="0" className="col-md-9 content">
-								<AUskipLink links={[
-									{
-										link: '#component-documentation',
-										text: `Skip to ${ pagetitle }`,
-									},
-								]} />
 								{
-									showheader && <Fragment>
+									showheader &&
+									<Fragment>
+										<AUskipLink links={[
+											{
+												link: '#component-documentation',
+												text: `Skip to ${ pagetitle }`,
+											},
+										]} />
 										<ComponentHeader
 											_relativeURL={ _relativeURL }
 											_parseYaml={ _parseYaml }

--- a/src/layout/page.js
+++ b/src/layout/page.js
@@ -62,7 +62,7 @@ const Page = ({
 			{ header }
 			<div className="page-wrapper">
 				<div className="content-wrapper">
-					<main tabIndex="0" id="content" className="main au-body container-fluid">
+					<main tabIndex="-1" id="content" className="main au-body container-fluid">
 						<div className="row">
 							<div className="col-md-12">
 								<h1 className={

--- a/src/layout/page.js
+++ b/src/layout/page.js
@@ -62,7 +62,7 @@ const Page = ({
 			{ header }
 			<div className="page-wrapper">
 				<div className="content-wrapper">
-					<main id="content" className="main au-body container-fluid">
+					<main tabIndex="0" id="content" className="main au-body container-fluid">
 						<div className="row">
 							<div className="col-md-12">
 								<h1 className={

--- a/src/layout/structure/header.js
+++ b/src/layout/structure/header.js
@@ -72,6 +72,7 @@ const Header = ({ title, title_badge, mainmenu, header_govau, _relativeURL, _ID,
 			<div
 				aria-hidden="true"
 				id="mainmenu"
+				tabIndex="0"
 				className="mainmenu au-body au-body--dark au-accordion__body au-accordion--closed">
 				<div className="container-fluid">
 					<div className="row">

--- a/src/layout/structure/header.js
+++ b/src/layout/structure/header.js
@@ -72,7 +72,7 @@ const Header = ({ title, title_badge, mainmenu, header_govau, _relativeURL, _ID,
 			<div
 				aria-hidden="true"
 				id="mainmenu"
-				tabIndex="0"
+				tabIndex="-1"
 				className="mainmenu au-body au-body--dark au-accordion__body au-accordion--closed">
 				<div className="container-fluid">
 					<div className="row">

--- a/src/sass/components/_avatar.scss
+++ b/src/sass/components/_avatar.scss
@@ -1,17 +1,20 @@
 .avatar {
+	border: 2px solid #fff;
 	overflow: hidden;
 	display: inline-block;
 	vertical-align: middle;
-	width: 2em;
-	height: 2em;
 	border-radius: 100%;
-	background-color: $AU-color-background-alt; // image loading placeholder
+	background-color: $AU-color-background-alt;
+	position: relative;
+	display: block;
 
 	img {
-		max-width: 100%;
+		max-width: 2em;
+		display: block;
 	}
 
-	&:hover {
-		opacity: 0.5;
+	&:hover img {
+		opacity: 0.8;
+		z-index: 10;
 	}
 }

--- a/src/sass/components/_callout-with-button.scss
+++ b/src/sass/components/_callout-with-button.scss
@@ -1,6 +1,5 @@
 .calloutWithButton {
 	@include AU-clearfix(); //not using .row because of it's -margins
-	@include AU-space( margin-top, 2unit );
 	@include AU-space( padding, 2unit );
 	background: $AU-color-background-shade;
 
@@ -11,6 +10,10 @@
 
 	@include AU-media( lg ){
 		@include AU-space( padding, 4unit );
+	}
+
+	* + & {
+		@include AU-space( margin-top, 2unit );
 	}
 }
 

--- a/src/sass/components/_component-documentation.scss
+++ b/src/sass/components/_component-documentation.scss
@@ -1,0 +1,3 @@
+* + .componentdocumentation {
+	@include AU-space( margin-top, 5unit );
+}

--- a/src/sass/components/_component-status.scss
+++ b/src/sass/components/_component-status.scss
@@ -56,8 +56,8 @@ $color-status--suggestion-gradient-end:   $AU-color-background-alt-shade;
 	}
 
 	.avatar {
-		@include AU-space( margin-right, 0.25unit );
-		@include AU-space( margin-bottom, 0.25unit );
+		@include AU-space( margin-left, -0.25unit );
+		@include AU-space( margin-right, -0.25unit );
 	}
 
 	.component-status__title {
@@ -160,17 +160,40 @@ $color-status--suggestion-gradient-end:   $AU-color-background-alt-shade;
 	& > li:first-child {
 		margin-left: 0;
 	}
+
+	&.component-status__definition__list--images {
+		@include AU-clearfix;
+
+		& > li {
+			position: relative;
+			float: left;
+
+			&:hover {
+				z-index: 10;
+			}
+		}
+	}
 }
 
 
 
 .component-status__definition__list__more {
+	margin-left: 1em;
+	width: 2.4em;
+	height: 2.4em;
+	padding: 0;
+	position: relative;
+	top: 2px;
+	border-radius: 100%;
 	appearance: none;
+	text-align: center;
 	background: transparent;
-	border: none;
+	color: $AU-color-foreground-action;
+	border: 2px solid $AU-color-foreground-action;
 	box-shadow: none;
 	cursor: pointer;
-	text-decoration: underline;
+	font-size: 12px;
+	display: block;
 
 	&.is-hidden {
 		display: none;
@@ -178,6 +201,9 @@ $color-status--suggestion-gradient-end:   $AU-color-background-alt-shade;
 
 	&:hover {
 		text-decoration: none;
+		text-decoration: underline;
+		color: $AU-color-foreground-text;
+		border-color: $AU-color-foreground-border;
 	}
 
 	@include AU-focus();

--- a/src/sass/components/_section.scss
+++ b/src/sass/components/_section.scss
@@ -1,3 +1,3 @@
-.section {
+* + .section {
 	@include AU-space( margin-top, 3.5unit );
 }

--- a/src/sass/style.scss
+++ b/src/sass/style.scss
@@ -30,6 +30,7 @@
 @import 'components/component-table';
 @import 'components/overlay';
 @import 'components/component-header';
+@import 'components/component-documentation';
 @import 'components/card';
 @import 'components/card--component';
 @import 'components/download-intro';


### PR DESCRIPTION
Fix #50, #84 and #72

- Added new skip link on component pages to skip header
- Added `tabindex="0"` to skip link areas
- Added screen reader only text to contributors area
- Adjusted how spacing works on component pages ( nothing should change from this )