### PR TITLE
Highlights for components, au-table around markdown tables, header focus lock

### DIFF
--- a/content/components/_all.yml
+++ b/content/components/_all.yml
@@ -756,6 +756,7 @@ header:
       img: hannah-j-nicdao.jpg
       url: 'https://au.linkedin.com/in/hannah-j-nicdao-78318024'
   state: published
+  highlight: update
   order: 10
   discussions:
     - open: 2

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
 	"requires": true,
 	"dependencies": {
 		"@gov.au/accordion": {
-			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/@gov.au/accordion/-/accordion-3.0.5.tgz",
-			"integrity": "sha512-oOPYVOUqhDADFGigtD1jADCJ6usgo/SIeCUKnz/RS2BKqqKjAUHZAtLudHoeJycd9d8s/cpFSOLzDr/plaOl+A==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@gov.au/accordion/-/accordion-4.0.0.tgz",
+			"integrity": "sha512-DaVdZNG+1CcJs0r6EQRwT27Q9jAAO8VUUXbqjRPsIxXLwnxMooWdWCnI5wY4C5GrsMqpGsrZnELJIYoa6t1BTQ==",
 			"requires": {
 				"@gov.au/animate": "^1.0.0",
 				"@gov.au/core": "^3.0.0",
@@ -19,9 +19,9 @@
 			}
 		},
 		"@gov.au/animate": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@gov.au/animate/-/animate-1.0.4.tgz",
-			"integrity": "sha512-vUqaZDv2BjJTyBR2/7wVSQKXPfqbkIKcvY6Kl+0tPYd2Ts1rkHHqq+yD8cjVta0AryjG6KNqDO7xcAFsxImYCg==",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/@gov.au/animate/-/animate-1.0.5.tgz",
+			"integrity": "sha512-+9XZH3VcVii6HC0HtgtKn9oJnjUn7pIuNKXHS2rHwhiHfljnrq/C0aNiEWWSiZmIftGpOf9PCRYYULHV29blkw==",
 			"requires": {
 				"@gov.au/pancake": "~1",
 				"@gov.au/pancake-js": "~1",
@@ -29,9 +29,9 @@
 			}
 		},
 		"@gov.au/body": {
-			"version": "2.0.7",
-			"resolved": "https://registry.npmjs.org/@gov.au/body/-/body-2.0.7.tgz",
-			"integrity": "sha512-YT8Jyzn5uvHq2vGO25z23665lR2jLiiOg9rKXGFRu2JAIhzw15CDqEmsP/Rf6gjtNky9AsvkmVaMGuRxE7qfzw==",
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/@gov.au/body/-/body-2.0.8.tgz",
+			"integrity": "sha512-r6PIBHBb/EmWL2ZeWzeKwsyn0m76siBzDIEOBYN+1F8iMVvCt5/EjQwG002BTQoToR/xfY8nzocRXiTYxiMhtA==",
 			"requires": {
 				"@gov.au/core": "^3.0.0",
 				"@gov.au/pancake": "~1",
@@ -40,12 +40,12 @@
 			}
 		},
 		"@gov.au/breadcrumbs": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/@gov.au/breadcrumbs/-/breadcrumbs-2.1.1.tgz",
-			"integrity": "sha512-FUsuVXbEU8uO6Ali7pkYnQAhaLnoho9A5T5VBP7Q3YBciBjIuPQMxWxHkJV0DLPbG6xPMkrUKCwVSGptxL5/NQ==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@gov.au/breadcrumbs/-/breadcrumbs-3.0.0.tgz",
+			"integrity": "sha512-j+hCP8B206p0qeQPPxVywi/mcRmEqikhsEIINuMOATubS+S1FV3ReqCbjFTfs04w3NSyfa1omW8DInAIXHTlZw==",
 			"requires": {
 				"@gov.au/core": "^3.0.0",
-				"@gov.au/link-list": "^2.1.0",
+				"@gov.au/link-list": "^3.0.0",
 				"@gov.au/pancake": "~1",
 				"@gov.au/pancake-json": "~1",
 				"@gov.au/pancake-react": "~1",
@@ -53,9 +53,9 @@
 			}
 		},
 		"@gov.au/buttons": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/@gov.au/buttons/-/buttons-3.0.1.tgz",
-			"integrity": "sha512-nOhbSi3t8B5yf7Y9sfRHYGB6nW7bUzapnV5/p3vgWS662T8DFknrpAt8iM54IRx/LJlWYX3NDotXVHDEUYwsDQ==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@gov.au/buttons/-/buttons-3.0.2.tgz",
+			"integrity": "sha512-9ugniaU3ZGzG042lSzlsn7Kt1S4sCIOOntFZAveSnGK2Fo8hnspUCTLiaGl8foFHDRQxpoksAkYHY3TQuIt9QA==",
 			"requires": {
 				"@gov.au/core": "^3.0.0",
 				"@gov.au/pancake": "~1",
@@ -65,9 +65,9 @@
 			}
 		},
 		"@gov.au/callout": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/@gov.au/callout/-/callout-2.0.5.tgz",
-			"integrity": "sha512-XrrCFz5vTXltBDjPZsZS9IsqAnahuJBefhP6T5LVwNfvprwHig4NeLICWzIYybULwUp690tnxyiSUqhYbDreyw==",
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/@gov.au/callout/-/callout-2.0.6.tgz",
+			"integrity": "sha512-x8oKIoR8c4g3LN3P28bnCUl5JoQX9FSdT8i2M9wkJ5SUEALFLfYMGwhB33RDN57jS2v5EpXagCRtP9k2fb8J9Q==",
 			"requires": {
 				"@gov.au/core": "^3.0.0",
 				"@gov.au/pancake": "~1",
@@ -77,9 +77,9 @@
 			}
 		},
 		"@gov.au/control-input": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/@gov.au/control-input/-/control-input-2.1.3.tgz",
-			"integrity": "sha512-wd6wr4EbC7k61PmXq4eTRAHjvN8HLbdETQ/r4IXdUitkxaU4dzNMQ+dh2NfHKEr47zEwFBlHszHpFKYC45b+5A==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@gov.au/control-input/-/control-input-2.1.4.tgz",
+			"integrity": "sha512-ZcnBwvvbMed6IUCb7+YQBKyRt7STMPCMRIis5cWT7TbHZxlxwMG8A9cAvxOL4VGJj7QcmvQOE7rKGSmWaBzt2Q==",
 			"requires": {
 				"@gov.au/core": "^3.0.0",
 				"@gov.au/pancake": "~1",
@@ -89,9 +89,9 @@
 			}
 		},
 		"@gov.au/core": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@gov.au/core/-/core-3.0.0.tgz",
-			"integrity": "sha512-N4HXoQ8UTBKCvhdeDjW5Zh7pX+v0nZGTU5s/LrIOUqnOFhCo3hkzvEhbZ22QGXCI48wOCCzCTrasM6WXBxkSMw==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@gov.au/core/-/core-3.0.1.tgz",
+			"integrity": "sha512-QZsISnzOqq9rj3YtaM5eL/zKyPQ9WFdqpuU6VGYY6F16Fw6MtUy+EKUPF6b+DpxMviSJWdFWFFVrThlHtZxtCg==",
 			"requires": {
 				"@gov.au/pancake": "~1",
 				"@gov.au/pancake-json": "~1",
@@ -100,9 +100,9 @@
 			}
 		},
 		"@gov.au/cta-link": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/@gov.au/cta-link/-/cta-link-2.1.1.tgz",
-			"integrity": "sha512-KXosJMdqfaTJ/wNpgiXmEw9uSaSbnH9EOh8cx6G3FcasgjZyVnQdPuIyTpQNilTN51xJ3xo7FYei0OISn9VlZw==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/@gov.au/cta-link/-/cta-link-2.1.2.tgz",
+			"integrity": "sha512-awRr6dMFtkwiBNcAm1z7u57TzebqwXbknrqEaHvXglulrJ0Dtm2Fk4EtkWUbaJcBqaPnXbOn6OLNdP1MeSdM6g==",
 			"requires": {
 				"@gov.au/core": "^3.0.0",
 				"@gov.au/pancake": "~1",
@@ -112,9 +112,9 @@
 			}
 		},
 		"@gov.au/direction-links": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/@gov.au/direction-links/-/direction-links-2.1.1.tgz",
-			"integrity": "sha512-Xrjmx11dF6ZLlYzJ7mwXf9z9v/Jh33XUyzWgf/xH5WGUzutD2i8Isb/XXP26XpuO9G8N6Rcz4RzupuvRP9DJLQ==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/@gov.au/direction-links/-/direction-links-2.1.2.tgz",
+			"integrity": "sha512-TIRCM8B4l2mgkfZCx139pY+lwSzi/L9iu4wEDVgC2Kx7ZrWQM9qwoIb5xDTi9uNTEPdLwik/al6NAqNrtku4gw==",
 			"requires": {
 				"@gov.au/core": "^3.0.0",
 				"@gov.au/pancake": "~1",
@@ -124,9 +124,9 @@
 			}
 		},
 		"@gov.au/footer": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/@gov.au/footer/-/footer-2.1.3.tgz",
-			"integrity": "sha512-JFC6dXMriDO/tOnnEnG5k5BphPTs58WyjZilFxH+UQTNzj69F/ghCBCVTTeTsR3sfM1Feu1NaWn6xbEVMbBKXA==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@gov.au/footer/-/footer-2.1.4.tgz",
+			"integrity": "sha512-mKyPR8ZEP3HeF/oNP+CoCYd+zp943NmSlLo5M3gF9HITjjNvGCGbyhUUg60KIHzmVjNl1jvb0CHyXMDRt3A0Lg==",
 			"requires": {
 				"@gov.au/core": "^3.0.0",
 				"@gov.au/pancake": "~1",
@@ -136,9 +136,9 @@
 			}
 		},
 		"@gov.au/grid-12": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/@gov.au/grid-12/-/grid-12-2.0.5.tgz",
-			"integrity": "sha512-wzFoVumbwBPyFYowtIpax4tXX5naCgKSkiKHKyGvNDvLEVv3bKyHAP4p/OPol4wH2vQ40BYfZ0oun+Eu2PV5GA==",
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/@gov.au/grid-12/-/grid-12-2.0.6.tgz",
+			"integrity": "sha512-4/gn/TFwRseqq7YqI7dv6gdekimthWJRlkpFCsulAJPdicj5Pmw/r4OkHoTtQ8LmqtgpeS20wVSacVltdPJ4zQ==",
 			"requires": {
 				"@gov.au/core": "^3.0.0",
 				"@gov.au/pancake": "~1",
@@ -147,9 +147,9 @@
 			}
 		},
 		"@gov.au/header": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/@gov.au/header/-/header-4.1.1.tgz",
-			"integrity": "sha512-Wezq7amG7c9mPRy61InbPf1/jvItSOSHiePLFIGkajP+1+anXMGt4qdbH+K6+Aaej3+XNSqh6zDL/+HT4aYhuw==",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/@gov.au/header/-/header-4.1.3.tgz",
+			"integrity": "sha512-H2jQlxCclfzoq4RadKyt2+eIzRnLMVC6dJ1MOQkICXVZkm1KgFf/dES3EpF80L0HspYE0XKshWNFkpnvmeRmoA==",
 			"requires": {
 				"@gov.au/core": "^3.0.0",
 				"@gov.au/pancake": "~1",
@@ -159,9 +159,9 @@
 			}
 		},
 		"@gov.au/headings": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/@gov.au/headings/-/headings-2.0.5.tgz",
-			"integrity": "sha512-0yCe7fH4pMfEEvexk07k/GzAFsd9GYXIby/shKolPXGwxkKXhLSQUFee0KVaUufr3QOjw/UlPemxzv0kSa0euQ==",
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/@gov.au/headings/-/headings-2.0.6.tgz",
+			"integrity": "sha512-01tv8kvaQMTiH+Ax7PtAR6Eo0EZZYhahmofY0RHIyUKg7liGLMBhlu6XLNAh1iGFXXoIhX+Wp14/Oc++9+TgnQ==",
 			"requires": {
 				"@gov.au/core": "^3.0.0",
 				"@gov.au/pancake": "~1",
@@ -171,12 +171,12 @@
 			}
 		},
 		"@gov.au/inpage-nav": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/@gov.au/inpage-nav/-/inpage-nav-2.0.5.tgz",
-			"integrity": "sha512-XjtFZ+ZSmTPic7vn95V35ZGcYLjpkAoi/FI78LOcERQOY1T84g5v9edYiHSY/0rLgIvzxU3TT5edYFCYxL9Ggw==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@gov.au/inpage-nav/-/inpage-nav-3.0.0.tgz",
+			"integrity": "sha512-1AbrXbheb7OBTsQwvA2c7Pr0gG2rFbxH1aIjZglkjRAjupSfZZ+YmkJLdQ796PWa6bqh+xW+uBvLqQw597EuCg==",
 			"requires": {
 				"@gov.au/core": "^3.0.0",
-				"@gov.au/link-list": "^2.1.0",
+				"@gov.au/link-list": "^3.0.0",
 				"@gov.au/pancake": "~1",
 				"@gov.au/pancake-json": "~1",
 				"@gov.au/pancake-react": "~1",
@@ -184,12 +184,12 @@
 			}
 		},
 		"@gov.au/keyword-list": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/@gov.au/keyword-list/-/keyword-list-2.1.1.tgz",
-			"integrity": "sha512-RSLOPZBsbpSYrEP/aCgJHYFs4SUClcGR5kS/L2rO2x/Ml6Aqmvp4psn6zwc4VOIfiHyUeiaft5cYUM7VovtAYw==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@gov.au/keyword-list/-/keyword-list-3.0.0.tgz",
+			"integrity": "sha512-4t9dxiRHi8RtAUl5IVK7R3V8wDgeNBK9RJBaIjYctJBUnrAFXdm0sqoEvY3rS96jPUNxlszAq261GahjOx6/BQ==",
 			"requires": {
 				"@gov.au/core": "^3.0.0",
-				"@gov.au/link-list": "^2.1.0",
+				"@gov.au/link-list": "^3.0.0",
 				"@gov.au/pancake": "~1",
 				"@gov.au/pancake-json": "~1",
 				"@gov.au/pancake-react": "~1",
@@ -197,9 +197,9 @@
 			}
 		},
 		"@gov.au/link-list": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/@gov.au/link-list/-/link-list-2.1.1.tgz",
-			"integrity": "sha512-/8RYBT5kWVhr/sbXSe/p8YqjY0yttuBSPZ9BHdjLHypYEoR44dJGV+UiOZeBpPrDelLQGzvl63z+gBiKtQs7EQ==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@gov.au/link-list/-/link-list-3.0.0.tgz",
+			"integrity": "sha512-Hx4ikn0+f8fXeS5TEmHour4bc27dLKBdKJBUttQ2VP8ysK3raDoiXTV1ETxJ8RN6+qI4oqLHQCF4VtefShbZzg==",
 			"requires": {
 				"@gov.au/body": "^2.0.0",
 				"@gov.au/core": "^3.0.0",
@@ -210,9 +210,9 @@
 			}
 		},
 		"@gov.au/page-alerts": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/@gov.au/page-alerts/-/page-alerts-2.0.5.tgz",
-			"integrity": "sha512-Qx/3PtpxczIGaD5JUowDrJl6rajwnHpFwbv89HOa6a6wbjFEsQ9WOxsLL8Ty1V7MYyx5W+j18x9zc5iMWPVxTA==",
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/@gov.au/page-alerts/-/page-alerts-2.0.6.tgz",
+			"integrity": "sha512-xyc8KJGj1+kLh1OKyOJ4/1VYqTXkIZCdz8eE5AT5WDfu8DBCZzX607CxYYnwt2ZFLccHzSue2XPB1WAn3OWjpg==",
 			"requires": {
 				"@gov.au/body": "^2.0.0",
 				"@gov.au/core": "^3.0.0",
@@ -297,9 +297,9 @@
 			}
 		},
 		"@gov.au/progress-indicator": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/@gov.au/progress-indicator/-/progress-indicator-3.1.1.tgz",
-			"integrity": "sha512-xpqTOjt1GEi/M2N5kaFTdo9aH0jI05m9Tt9qjY6yj+Hrq9CKEEkaqyDyhqrXtW1WV7NE2+0BZmUPVi/9nlVeIA==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@gov.au/progress-indicator/-/progress-indicator-3.1.2.tgz",
+			"integrity": "sha512-+i7wrWZ5K0CDlMMoYOtMZJINQc78apt6xN19F+eMU7YkfXkWEH8SxOroOqI8heFa0gAWVHbX499etug5D5irpA==",
 			"requires": {
 				"@gov.au/core": "^3.0.0",
 				"@gov.au/pancake": "~1",
@@ -309,9 +309,9 @@
 			}
 		},
 		"@gov.au/responsive-media": {
-			"version": "2.0.8",
-			"resolved": "https://registry.npmjs.org/@gov.au/responsive-media/-/responsive-media-2.0.8.tgz",
-			"integrity": "sha512-fZK1fzBvYLmgcjinNDtav6nROXZVnduuKz0UY7vyqGeIr3ZPEFPgLYpcgjBqp/Nsh2pX44L39qd1nNDW+1znJw==",
+			"version": "2.0.9",
+			"resolved": "https://registry.npmjs.org/@gov.au/responsive-media/-/responsive-media-2.0.9.tgz",
+			"integrity": "sha512-MSfn0qCIDnlR9x+1iYJOzxO1bT0jT5EpNk3RDlWOABZka+aQKIWDnQ7W5ryicHCcueIE0xcRWb8JWdeBp0CR5A==",
 			"requires": {
 				"@gov.au/core": "^3.0.0",
 				"@gov.au/pancake": "~1",
@@ -320,9 +320,9 @@
 			}
 		},
 		"@gov.au/select": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/@gov.au/select/-/select-2.0.5.tgz",
-			"integrity": "sha512-PsCf18/OW+KfVqEfP27YaRd8+zPNKGrj0XlFvCz6IgPVhR5Dp67PAZgjhOLaWOFOvATsNH+GM9hFKy7UVpEkPw==",
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/@gov.au/select/-/select-2.0.6.tgz",
+			"integrity": "sha512-oqzReVKxHzDz2CEGru/9j8joqVNDYcxLvYQImIMadGAviHggX8q35Un2DRKQ3HDqQycyEt55nUdsVysXXP8oqA==",
 			"requires": {
 				"@gov.au/core": "^3.0.0",
 				"@gov.au/pancake": "~1",
@@ -332,9 +332,9 @@
 			}
 		},
 		"@gov.au/skip-link": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/@gov.au/skip-link/-/skip-link-2.0.6.tgz",
-			"integrity": "sha512-spMIUPQlt/WM825PQswZaN0SjxN9cLWeMIZth60+vgBXo315ZLBn7ts79q8xA9LarV5x0Ygtq2jyB5igmSU4gg==",
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/@gov.au/skip-link/-/skip-link-2.0.7.tgz",
+			"integrity": "sha512-H8PA36KVn6hwPGa4Ci1nuYdAFB6GCdQTTd38+7N4yXU5izq8ueJ8AGW7ckBT+HEUzpUJ3oo8xLKq+D1palTvZg==",
 			"requires": {
 				"@gov.au/core": "^3.0.0",
 				"@gov.au/pancake": "~1",
@@ -344,9 +344,9 @@
 			}
 		},
 		"@gov.au/tags": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/@gov.au/tags/-/tags-3.1.1.tgz",
-			"integrity": "sha512-tQCJissKkn708P3fMps139TQ24MtvCmyzGahu4LGHj0gSNxox/WqlA45mOv7s9e+4gFV/t9dP/Y8AhPs0n8FBA==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@gov.au/tags/-/tags-3.1.2.tgz",
+			"integrity": "sha512-v7psA49fu4d2yYU6K9vTqsSu22Q0df/8pToglCFWKCjGBdC2SAwUT1mbu83Ycum0AH8Mu4KH/YxJEl6ZavENnA==",
 			"requires": {
 				"@gov.au/core": "^3.0.0",
 				"@gov.au/pancake": "~1",
@@ -356,9 +356,9 @@
 			}
 		},
 		"@gov.au/text-inputs": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/@gov.au/text-inputs/-/text-inputs-2.0.6.tgz",
-			"integrity": "sha512-FijC1CSWN7Igd9JOac7lrfuskW8Tnv5/nCapOoQQFgADHgZURyM+ivC5qn36xVyzxEZFmnwbHNRQsgw96R+UVg==",
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/@gov.au/text-inputs/-/text-inputs-2.0.7.tgz",
+			"integrity": "sha512-3RuEAsC2glhwjy8Td3qR0XF90TC6mbftuuUD0ZCFuiFgWrELr2xoOnD+wFczrDLS9IznCobrsoqvW9I3Bjd6HA==",
 			"requires": {
 				"@gov.au/core": "^3.0.0",
 				"@gov.au/pancake": "~1",

--- a/src/layout/component/navigation-accordion.js
+++ b/src/layout/component/navigation-accordion.js
@@ -34,9 +34,13 @@ const NavigationAccordion = ({ _relativeURL, _ID, _pages, _parents, _parseYaml }
 		const navItems = [];
 		components.map( component => {
 
+			const label = component.highlight
+				? <Fragment>{ component.name } <strong className="badge badge--highlight">{ component.highlight }</strong></Fragment>
+				: component.name;
+
 			const link = {
 				link: `/components/${ component.ID }`,
-				text: component.name
+				text: label
 			}
 
 			navItems.push( CreateLink( link, _relativeURL, _ID, _pages ) );

--- a/src/layout/component/released.js
+++ b/src/layout/component/released.js
@@ -16,7 +16,8 @@ const ComponentReleased = ({ cardList, _ID, _body, _parseYaml, _relativeURL }) =
 
 	const cards = [];
 	components.map( component => {
-		cards.push({
+
+		const cardData = {
 			link: _relativeURL( `/components/${ component.ID }`, _ID ),
 			rows: [{
 				type: 'svg',
@@ -30,7 +31,16 @@ const ComponentReleased = ({ cardList, _ID, _body, _parseYaml, _relativeURL }) =
 				headingSize: '3',
 				text: component.name,
 			}]
-		})
+		}
+
+		if ( component.highlight ) {
+			cardData.rows.push ({
+				type: 'html',
+				html: <div className="card__highlight">{ component.highlight }</div>
+			})
+		}
+
+		cards.push(cardData);
 	})
 
 	return(

--- a/src/markdown/renderer.js
+++ b/src/markdown/renderer.js
@@ -82,5 +82,18 @@ module.exports = exports = function renderer({ Marked, _ID, _relativeURL }) {
 	};
 
 
+	/**
+	 * Table overwrite
+	 *
+	 * @param {string} header - The title of the table
+	 * @param {string} body   - The body of the table
+	 *
+	 * @return {string}       - The table element
+	 */
+	Marked.table = ( header, body ) => {
+		return `<div class="au-table au-table--responsive">\n<table>\n<thead>\n${ header }</thead>\n<tbody>\n${ body }</tbody>\n</table>\n</div>\n`;
+	};
+
+
 	return Marked;
 };

--- a/src/sass/components/_badge.scss
+++ b/src/sass/components/_badge.scss
@@ -7,3 +7,8 @@
 	font-weight: normal;
 	float: right;
 }
+
+.badge--highlight {
+	background-color: $AU-color-background-alt;
+	color: $AU-color-foreground-muted;
+}

--- a/src/sass/components/_card--component.scss
+++ b/src/sass/components/_card--component.scss
@@ -1,4 +1,6 @@
 .au-card {
+	position: relative; // for card__highlight
+
 	&.au-card--border {
 		@include AU-space( padding, 1unit 0 );
 		@include AU-space( border-top, 0.5unit solid $AU-color-foreground-border );
@@ -31,4 +33,21 @@
 		@include AU-fontgrid( xs );
 		color: $AU-color-foreground-muted;
 	}
+}
+
+.card__highlight {
+	@include AU-space( padding, 0.25unit 0 );
+	font-size: 12px;
+	font-size: 0.75rem;
+	line-height: 1;
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 100%;
+	background-color: $AU-color-success-a11y;
+	color: $AU-color-background;
+	font-weight: bold;
+	text-align: center;
+	transform-origin: left top;
+	transform: rotate( 315deg ) translateX( -50% ) translateY( 20px );
 }


### PR DESCRIPTION
Fixes #143 Fixes #170 Fixes #172

This PR:
- Wraps all markdown tables with `.au-table .au-table--responsive`.
- Adds highlighted statuses for components, `updated`, `new`
- Fixes a bug in the header that incorrectly made it an `<a>` instead of a `<div>`