### PR TITLE
update number of projects on home page

### DIFF
--- a/content/index/statisitics.md
+++ b/content/index/statisitics.md
@@ -6,7 +6,7 @@ btntext: See our Performance Dashboard
 
 tiles:
   - description: Live projects
-    number: 13
+    number: 14
 
 # https://www.dta.gov.au/
 # https://beta.dta.gov.au
@@ -21,6 +21,7 @@ tiles:
 # https://beta.health.gov.au/
 # https://asbestossafety.gov.au/
 # https://search.data.gov.au/
+# https://hub.casa.gov.au/content/casa/home.html
 
   - description: GitHub stars
     number: stars


### PR DESCRIPTION
Update number of projects to 14. 

The Civil Aviation Safety Authority's new service to allow users to apply for Aviation Reference Numbers built uses components from the design system.