### PR TITLE
Update the page-alert examples titles to their correct names

### DIFF
--- a/content/_data.yml
+++ b/content/_data.yml
@@ -2,42 +2,42 @@
 # THE `pancake` and `uikit` FIELDS WILL BE OVERWRITTEN
 
 pancake:
-  download: 103396
+  download: 103931
   modules:
-    '@gov.au/pancake': 24576
-    '@gov.au/pancake-js': 15997
-    '@gov.au/pancake-json': 17018
-    '@gov.au/pancake-react': 20248
-    '@gov.au/pancake-sass': 24919
+    '@gov.au/pancake': 24658
+    '@gov.au/pancake-js': 16081
+    '@gov.au/pancake-json': 17120
+    '@gov.au/pancake-react': 20326
+    '@gov.au/pancake-sass': 25108
     '@gov.au/syrup': 638
   stars: 68
 uikit:
-  download: 312349
+  download: 313882
   modules:
-    '@gov.au/accordion': 15520
-    '@gov.au/animate': 15645
-    '@gov.au/body': 19580
-    '@gov.au/breadcrumbs': 10936
-    '@gov.au/buttons': 19813
-    '@gov.au/callout': 8369
-    '@gov.au/control-input': 10226
-    '@gov.au/core': 21769
-    '@gov.au/cta-link': 13985
-    '@gov.au/direction-links': 7454
-    '@gov.au/footer': 17184
-    '@gov.au/grid-12': 18042
-    '@gov.au/header': 14033
-    '@gov.au/headings': 12086
-    '@gov.au/inpage-nav': 9415
-    '@gov.au/keyword-list': 5312
-    '@gov.au/link-list': 17514
-    '@gov.au/main-nav': 196
-    '@gov.au/page-alerts': 12250
-    '@gov.au/progress-indicator': 6819
-    '@gov.au/responsive-media': 7906
-    '@gov.au/select': 10235
-    '@gov.au/side-nav': 1012
-    '@gov.au/skip-link': 13457
-    '@gov.au/tags': 9101
-    '@gov.au/text-inputs': 14490
+    '@gov.au/accordion': 15618
+    '@gov.au/animate': 15727
+    '@gov.au/body': 19663
+    '@gov.au/breadcrumbs': 11002
+    '@gov.au/buttons': 19892
+    '@gov.au/callout': 8391
+    '@gov.au/control-input': 10251
+    '@gov.au/core': 21852
+    '@gov.au/cta-link': 14051
+    '@gov.au/direction-links': 7482
+    '@gov.au/footer': 17252
+    '@gov.au/grid-12': 18127
+    '@gov.au/header': 14102
+    '@gov.au/headings': 12126
+    '@gov.au/inpage-nav': 9423
+    '@gov.au/keyword-list': 5338
+    '@gov.au/link-list': 17582
+    '@gov.au/main-nav': 213
+    '@gov.au/page-alerts': 12334
+    '@gov.au/progress-indicator': 6842
+    '@gov.au/responsive-media': 7933
+    '@gov.au/select': 10320
+    '@gov.au/side-nav': 1039
+    '@gov.au/skip-link': 13558
+    '@gov.au/tags': 9186
+    '@gov.au/text-inputs': 14578
   stars: 282

--- a/content/components/page-alerts/accessibility/code.md
+++ b/content/components/page-alerts/accessibility/code.md
@@ -1,41 +1,41 @@
 <div class="au-page-alerts au-page-alerts--info" role="alert">
-  <h3>Alert title</h3>
+  <h3>Important</h3>
   <p>Alert Content <a href="#">link</a></p>
 </div>
 
 <div class="au-page-alerts au-page-alerts--success" role="alert">
-  <h3>Alert title</h3>
+  <h3>Success</h3>
   <p>Alert Content <a href="#">link</a></p>
 </div>
 
 <div class="au-page-alerts au-page-alerts--error" role="alert">
-  <h3>Alert title</h3>
+  <h3>Error</h3>
   <p>Alert Content <a href="#">link</a></p>
 </div>
 
 <div class="au-page-alerts au-page-alerts--warning" role="alert">
-  <h3>Alert title</h3>
+  <h3>Warning</h3>
   <p>Alert content <a href="#">link</a></p>
 </div>
 
 <div class="au-body au-body--dark">
   <div class="au-page-alerts au-page-alerts--info" role="alert">
-    <h3>Alert title</h3>
+    <h3>Important</h3>
     <p>Alert Content <a href="#">link</a></p>
   </div>
 
   <div class="au-page-alerts au-page-alerts--success" role="alert">
-    <h3>Alert title</h3>
+    <h3>Success</h3>
     <p>Alert Content <a href="#">link</a></p>
   </div>
 
   <div class="au-page-alerts au-page-alerts--error" role="alert">
-    <h3>Alert title</h3>
+    <h3>Error</h3>
     <p>Alert Content <a href="#">link</a></p>
   </div>
 
   <div class="au-page-alerts au-page-alerts--warning" role="alert">
-    <h3>Alert title</h3>
+    <h3>Warning</h3>
     <p>Alert content <a href="#">link</a></p>
   </div>
 </div>

--- a/content/components/page-alerts/default.md
+++ b/content/components/page-alerts/default.md
@@ -12,7 +12,7 @@ code:
       -->
 
       <div role="alert" class="au-body au-page-alerts au-page-alerts--info">
-        <h3>Alert title</h3>
+        <h3>Important</h3>
         <p>Alert Content</p>
       </div>
   - React: |
@@ -26,7 +26,7 @@ code:
       import AUpageAlert from '@gov.au/page-alerts';
 
       <AUpageAlert as='info'>
-        <h3>Alert title</h3>
+        <h3>Important</h3>
         <p>Alert Content</p>
       </AUpageAlert>
 ---

--- a/content/components/page-alerts/error.md
+++ b/content/components/page-alerts/error.md
@@ -12,7 +12,7 @@ code:
       -->
 
       <div role="alert" class="au-body au-page-alerts au-page-alerts--error">
-        <h3>Alert title</h3>
+        <h3>Error</h3>
         <p>Alert Content</p>
       </div>
   - React: |
@@ -26,7 +26,7 @@ code:
       import AUpageAlert from '@gov.au/page-alerts';
 
       <AUpageAlert as='error'>
-        <h3>Alert title</h3>
+        <h3>Error</h3>
         <p>Alert Content</p>
       </AUpageAlert>
 ---

--- a/content/components/page-alerts/examples/example-default/code.md
+++ b/content/components/page-alerts/examples/example-default/code.md
@@ -1,11 +1,11 @@
 <div class="au-body au-page-alerts au-page-alerts--info" role="alert">
-  <h3>Alert title</h3>
+  <h3>Important</h3>
   <p>Alert Content with <a href="#">link</a></p>
 </div>
 
 <div class="au-body au-body--dark">
   <div class="au-page-alerts au-page-alerts--info au-page-alerts--dark" role="alert">
-    <h3>Alert title</h3>
+    <h3>Important</h3>
     <p>Alert Content <a href="#">link</a></p>
   </div>
 </div>

--- a/content/components/page-alerts/examples/example-error/code.md
+++ b/content/components/page-alerts/examples/example-error/code.md
@@ -1,11 +1,11 @@
 <div class="au-body au-page-alerts au-page-alerts--error" role="alert">
-  <h3>Alert title</h3>
+  <h3>Error</h3>
   <p>Alert Content <a href="#">link</a></p>
 </div>
 
 <div class="au-body au-body--dark">
   <div class="au-page-alerts au-page-alerts--error au-page-alerts--dark" role="alert">
-    <h3>Alert title</h3>
+    <h3>Error</h3>
     <p>Alert Content <a href="#">link</a></p>
   </div>
 </div>

--- a/content/components/page-alerts/examples/example-success/code.md
+++ b/content/components/page-alerts/examples/example-success/code.md
@@ -1,11 +1,11 @@
 <div class="au-body au-page-alerts au-page-alerts--success" role="alert">
-  <h3>Alert title</h3>
+  <h3>Success</h3>
   <p>Alert Content <a href="#">link</a></p>
 </div>
 
 <div class="au-body au-body--dark">
   <div class="au-page-alerts au-page-alerts--success au-page-alerts--dark" role="alert">
-    <h3>Alert title</h3>
+    <h3>Success</h3>
     <p>Alert Content <a href="#">link</a></p>
   </div>
 </div>

--- a/content/components/page-alerts/examples/example-warning/code.md
+++ b/content/components/page-alerts/examples/example-warning/code.md
@@ -1,11 +1,11 @@
 <div class="au-body au-page-alerts au-page-alerts--warning" role="alert">
-  <h3>Alert title</h3>
+  <h3>Warning</h3>
   <p>Alert content <a href="#">link</a></p>
 </div>
 
 <div class="au-body au-body--dark">
   <div class="au-page-alerts au-page-alerts--warning au-page-alerts--dark" role="alert">
-    <h3>Alert title</h3>
+    <h3>Warning</h3>
     <p>Alert content <a href="#">link</a></p>
   </div>
 </div>

--- a/content/components/page-alerts/rationale/icons.md
+++ b/content/components/page-alerts/rationale/icons.md
@@ -15,4 +15,4 @@ The solution relies on a few factors:
 
 **Icon symbols.** The colour of the icon symbols is the same as the text-colour, and the background for the symbol is always the same as the background colour. This guarantees that the icon symbol will always pass colour contrast ratio (provided that the default text and background do).
 
-**Alert title.** We can't simply rely on icons and colour to convey meaning, so an alert title should always accompany the alert text.
+**Alert title.** We can't simply rely on icons and colour to convey meaning, so an alert title should always accompany the alert text. Using a meaningful title like "Error" in the occurance of an error can help users who can not perceive or understand meaningful colors.

--- a/content/components/page-alerts/rationale/icons.md
+++ b/content/components/page-alerts/rationale/icons.md
@@ -9,7 +9,7 @@ The visual design of the page-alerts was a challenging problem to resolve due to
 2. The component can't rely on colours to indicate meaning.
 3. The component also comes in light and dark themes.
 
-The solution relys on a few factors:
+The solution relies on a few factors:
 
 **Icon shape.** The icons selected use different background shapes to convey some meaning and draw inspiration from the shape of Australian traffic signals to convey severity.
 

--- a/content/components/page-alerts/success.md
+++ b/content/components/page-alerts/success.md
@@ -12,7 +12,7 @@ code:
       -->
 
       <div role="alert" class="au-body au-page-alerts au-page-alerts--success">
-        <h3>Alert title</h3>
+        <h3>Success</h3>
         <p>Alert Content</p>
       </div>
   - React: |
@@ -26,7 +26,7 @@ code:
       import AUpageAlert from '@gov.au/page-alerts';
 
       <AUpageAlert as='success'>
-        <h3>Alert title</h3>
+        <h3>Success</h3>
         <p>Alert Content</p>
       </AUpageAlert>
 ---

--- a/content/components/page-alerts/warning.md
+++ b/content/components/page-alerts/warning.md
@@ -12,7 +12,7 @@ code:
       -->
 
       <div role="alert" class="au-body au-page-alerts au-page-alerts--warning">
-        <h3>Alert title</h3>
+        <h3>Warning</h3>
         <p>Alert Content</p>
       </div>
   - React: |
@@ -26,7 +26,7 @@ code:
       import AUpageAlert from '@gov.au/page-alerts';
 
       <AUpageAlert as='warning'>
-        <h3>Alert title</h3>
+        <h3>Warning</h3>
         <p>Alert Content</p>
       </AUpageAlert>
 ---


### PR DESCRIPTION
Fixes https://github.com/govau/uikit/issues/412