### PR TITLE
Fix checked, defaultChecked issue in terminal

### DIFF
--- a/src/layout/download/furnace.js
+++ b/src/layout/download/furnace.js
@@ -70,7 +70,7 @@ const Furnace = ({ components, _ID, _body, _parseYaml, _relativeURL }) => {
 														className="au-control-input__input js-furnace-selector"
 														value={ MODULES[ module ].ID }
 														required={ MODULES[ module ].required }
-														checked={ MODULES[ module ].required }
+														defaultChecked={ MODULES[ module ].required }
 														disabled={ MODULES[ module ].required }
 														readOnly={ MODULES[ module ].required }
 													/>


### PR DESCRIPTION
When you run `npm run watch` you should no longer get a warning about `checked` and `defaultChecked`