### PR TITLE
Update to Footer Affiliate link

### DIFF
--- a/src/layout/structure/footer.js
+++ b/src/layout/structure/footer.js
@@ -36,7 +36,7 @@ const Footer = ({ headline, legallist, mainlist, _body, _ID, _relativeURL }) => 
 							<span>An initiative of the </span>
 							<span>Digital Transformation Agency </span>
 							<span className="footer__affiliate-link">
-								<AUctaLink link="http://dta.gov.au/" text="More projects" dark/>
+								<AUctaLink link="http://dta.gov.au/what-we-do" text="More projects" dark/>
 							</span>
 						</p>
 					</div>


### PR DESCRIPTION
This pull request updates the `footer affiliate` class, to link to the [what we do](https://www.dta.gov.au/what-we-do/) page instead of the home page of [dta.gov.au](dta.gov.au)