### PR TITLE
Removed aria-selected from headergovau__bar as best practice

### DIFF
--- a/src/layout/structure/header-govau.js
+++ b/src/layout/structure/header-govau.js
@@ -9,7 +9,7 @@ import React, { Fragment } from 'react';
 const HeaderGovAU = ({ publisher, publisher_url, left_title, left_content, right_title, right_content }) => (
 	<div className="headergovau">
 		<div className="container-fluid">
-			<div className="row headergovau__bar" role="tablist">
+			<div className="row headergovau__bar" role="presentation">
 				<div className="col-md-12">
 					<a
 						href="#headergovau-accordion"

--- a/src/layout/structure/header-govau.js
+++ b/src/layout/structure/header-govau.js
@@ -9,11 +9,12 @@ import React, { Fragment } from 'react';
 const HeaderGovAU = ({ publisher, publisher_url, left_title, left_content, right_title, right_content }) => (
 	<div className="headergovau">
 		<div className="container-fluid">
-			<div className="row headergovau__bar">
+			<div className="row headergovau__bar" role="tablist">
 				<div className="col-md-12">
 					<a
 						href="#headergovau-accordion"
 						className="headergovau__button js-header-accordion au-accordion--closed"
+						role="tab"
 						aria-controls="headergovau-accordion"
 						aria-expanded="false"
 						aria-selected="false"

--- a/src/layout/structure/header-govau.js
+++ b/src/layout/structure/header-govau.js
@@ -7,22 +7,20 @@ import React               from 'react';
 const HeaderGovAU = ({ publisher, publisher_url, left_title, left_content, right_title, right_content }) => (
 	<div className="headergovau">
 		<div className="container-fluid">
-			<div className="row headergovau__bar" role="presentation">
+			<div className="row headergovau__bar">
 				<div className="col-md-12">
-					<a
+					<button
 						href="#headergovau-accordion"
 						className="headergovau__button js-header-accordion au-accordion--closed"
-						role="link"
 						aria-controls="headergovau-accordion"
 						aria-expanded="false"
-						aria-selected="false"
 						onClick="return AU.accordion.Toggle( this )"
 					>
 						<span className="headergovau__text">
 							<span className="headergovau__title">Australian Government&nbsp;</span>
 							<span className="headergovau__official">official website</span>
 						</span>
-					</a>
+					</button>
 					<a href={ publisher_url } className="headergovau__publisher">
 						{ publisher }
 					</a>

--- a/src/layout/structure/header-govau.js
+++ b/src/layout/structure/header-govau.js
@@ -1,7 +1,5 @@
-import AUlinkList          from '../../_uikit/layout/link-list';
-
 import PropTypes           from 'prop-types';
-import React, { Fragment } from 'react';
+import React               from 'react';
 
 /**
  * The headergovau component
@@ -14,7 +12,7 @@ const HeaderGovAU = ({ publisher, publisher_url, left_title, left_content, right
 					<a
 						href="#headergovau-accordion"
 						className="headergovau__button js-header-accordion au-accordion--closed"
-						role="tab"
+						role="link"
 						aria-controls="headergovau-accordion"
 						aria-expanded="false"
 						aria-selected="false"

--- a/src/layout/structure/header-govau.js
+++ b/src/layout/structure/header-govau.js
@@ -9,7 +9,7 @@ const HeaderGovAU = ({ publisher, publisher_url, left_title, left_content, right
 		<div className="container-fluid">
 			<div className="row headergovau__bar">
 				<div className="col-md-12">
-					<button
+					<a
 						href="#headergovau-accordion"
 						className="headergovau__button js-header-accordion au-accordion--closed"
 						aria-controls="headergovau-accordion"
@@ -20,7 +20,7 @@ const HeaderGovAU = ({ publisher, publisher_url, left_title, left_content, right
 							<span className="headergovau__title">Australian Government&nbsp;</span>
 							<span className="headergovau__official">official website</span>
 						</span>
-					</button>
+					</a>
 					<a href={ publisher_url } className="headergovau__publisher">
 						{ publisher }
 					</a>


### PR DESCRIPTION
This PR removes the `aria-selected` attribute from the `headergovau-accordion` element in an effort to implement best aria practice.  Following best practice, as the current `<a>` element doesn't actually link anywhere, it should technically be a button as outlined by Sarah Pulis an accessibility expert.

Additionally, I've removed some unused imports.

We should also look at what this means for the https://github.com/govau/uikit  accordion module.