### PR TITLE
Removed nightly rebuild from CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,13 +130,3 @@ workflows:
                 filters:
                   branches:
                     only: /.*-test/ # and only on the branches that end with `-test`
-
-    nightly-rebuild:            # rerun a task via scheduling, all times are UTC https://circleci.com/docs/2.0/workflows/#scheduling-a-workflow
-        triggers:
-          - schedule:
-              cron: "0 14 * * *"  # 2PM utc => 1am or midnight (daylight saving)
-              filters:
-                branches:
-                  only: master    # we only run the master branch
-        jobs:
-            - deploy-prod           # and only the production deploy


### PR DESCRIPTION
It doesn't really make sense to have nightly rebuilds considering every commit always gets built.